### PR TITLE
Remove liftMaybe function for GHC8 compatibility

### DIFF
--- a/library/HTMLEntities/Parser.hs
+++ b/library/HTMLEntities/Parser.hs
@@ -29,6 +29,4 @@ htmlEntity =
     numeric =
       Text.singleton . chr <$> (char '#' *> (decimal <|> (char 'x' *> hexadecimal)))
     named =
-      takeWhile1 isAlpha >>= liftMaybe . NameTable.lookupTextByName
-    liftMaybe =
-      maybe empty pure
+      takeWhile1 isAlpha >>= maybe (fail "empty") string . NameTable.lookupTextByName


### PR DESCRIPTION
Looks like some change on GHC8 changed ImpredicativeTypes
behavior and it doesn't accept liftMaybe function without cluttering
it with type annotations.

Here is the minimal working example of the GHC change, this code compiles with GHC 7.10.3, but not with GHC 8.0.1:

```
{-# LANGUAGE ImpredicativeTypes #-}

module Main where

import           Control.Applicative

liftMaybe :: Alternative f => Maybe a -> f a
liftMaybe = maybe empty pure

main :: IO ()
main = return ()
```

Just removing `ImpredicativeTypes` language extension from .cabal also fixes this issue, but I thought that's probably some boilerplate you use one every project and you don't want it to differ much between your other projects.
