### PR TITLE
Use QuasiQuote to reduce object file size by 95%

### DIFF
--- a/html-entities.cabal
+++ b/html-entities.cabal
@@ -43,5 +43,6 @@ library
   build-depends:
     attoparsec >=0.14 && <0.15,
     base >=4.11 && <5,
+    template-haskell,
     text >=1 && <3,
     unordered-containers >=0.2 && <0.3,

--- a/library/HTMLEntities/NameTable.hs
+++ b/library/HTMLEntities/NameTable.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+
 -- |
 -- A named entities table as per
 -- <https://html.spec.whatwg.org/multipage/entities.json>.
@@ -32,7 +36,7 @@ nameByTextTable =
 
 {-# INLINE list #-}
 list :: [(Text, Text)]
-list =
+list = read [lit|
   [ ("Aacute", "\x00C1"),
     ("Aacute", "\x00C1"),
     ("aacute", "\x00E1"),
@@ -2265,3 +2269,4 @@ list =
     ("zwj", "\x200D"),
     ("zwnj", "\x200C")
   ]
+  |]

--- a/library/HTMLEntities/Prelude.hs
+++ b/library/HTMLEntities/Prelude.hs
@@ -1,5 +1,6 @@
 module HTMLEntities.Prelude
   ( module Exports,
+    literally, lit, litFile
   )
 where
 
@@ -57,6 +58,8 @@ import GHC.Exts as Exports (IsList (..), groupWith, inline, lazy, sortWith)
 import GHC.Generics as Exports (Generic)
 import GHC.IO.Exception as Exports
 import GHC.OverloadedLabels as Exports
+import Language.Haskell.TH
+import Language.Haskell.TH.Quote
 import Numeric as Exports
 import System.Environment as Exports
 import System.Exit as Exports
@@ -71,3 +74,12 @@ import Text.ParserCombinators.ReadPrec as Exports (ReadPrec, readP_to_Prec, read
 import Text.Printf as Exports (hPrintf, printf)
 import Unsafe.Coerce as Exports
 import Prelude as Exports hiding (Read, all, and, any, concat, concatMap, elem, fail, foldl, foldl1, foldr, foldr1, id, mapM, mapM_, maximum, minimum, notElem, or, product, sequence, sequence_, sum, (.))
+
+literally :: String -> Q Exp
+literally = return . LitE . StringL
+
+lit :: QuasiQuoter
+lit = QuasiQuoter { quoteExp = literally }
+
+litFile :: QuasiQuoter
+litFile = quoteFile lit


### PR DESCRIPTION
This patch reduces the object file size of the HTMLEntities.NameTable module by 95%, from 2M to about 89K.  The improvement under GHCJS is about 99.5%, from 259M to 170K.  It uses a technique found here: https://stackoverflow.com/questions/12716215/load-pure-global-variable-from-file