### PR TITLE
Fix build with GHC 9.8

### DIFF
--- a/library/HTMLEntities/Prelude.hs
+++ b/library/HTMLEntities/Prelude.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module HTMLEntities.Prelude
   ( module Exports,
   )
@@ -25,7 +27,13 @@ import Data.Either as Exports
 import Data.Fixed as Exports
 import Data.Foldable as Exports hiding (toList)
 import Data.Function as Exports hiding (id, (.))
+
+#if MIN_VERSION_base(4, 19, 0)
+import Data.Functor as Exports hiding (unzip)
+#else
 import Data.Functor as Exports
+#endif
+
 import Data.Functor.Compose as Exports
 import Data.IORef as Exports
 import Data.Int as Exports


### PR DESCRIPTION
I ran into this error:

```
library/HTMLEntities/Prelude.hs:2:5: error: [GHC-69158]
    Conflicting exports for ‘unzip’:
       ‘module Exports’ exports ‘Exports.unzip’
         imported from ‘Data.Functor’ at library/HTMLEntities/Prelude.hs:28:1-30
       ‘module Exports’ exports ‘Exports.unzip’
         imported from ‘Prelude’ at library/HTMLEntities/Prelude.hs:73:1-203
         (and originally defined in ‘GHC.List’)
  |
2 |   ( module Exports,
  |     ^^^^^^^^^^^^^^
```

- https://github.com/haskell/core-libraries-committee/issues/88
- https://github.com/nikita-volkov/bytestring-strict-builder/issues/12