### PR TITLE
Use quasiquote to reduce object file size and compile time for the NameTable module

### DIFF
--- a/html-entities.cabal
+++ b/html-entities.cabal
@@ -78,5 +78,6 @@ library
   build-depends:
     , attoparsec >=0.14 && <0.15
     , base >=4.11 && <5
+    , template-haskell
     , text >=1 && <3
     , unordered-containers >=0.2 && <0.3

--- a/library/HTMLEntities/NameTable.hs
+++ b/library/HTMLEntities/NameTable.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+
 -- |
 -- A named entities table as per
 -- <https://html.spec.whatwg.org/multipage/entities.json>.
@@ -30,9 +34,23 @@ nameByTextTable :: HM.HashMap Text Text
 nameByTextTable =
   HM.fromList $ map swap list
 
+-- ghc-8.6.5 performance:
+--
+-- old build time:             6.936s
+-- old NameTable.o size:      2004584
+-- new build time:             3.775s
+-- new NameTable.o size:        89640
+--
+-- ghcjs-8.6 performance:
+--
+-- old build time:            12.227s
+-- old NameTable.js_o size: 271045795 (yes, 271 megabytes)
+-- new build time:             3.931s
+-- new NameTable.js_o size:    169604
+
 {-# INLINE list #-}
 list :: [(Text, Text)]
-list =
+list = read [lit|
   [ ("Aacute", "\x00C1"),
     ("Aacute", "\x00C1"),
     ("aacute", "\x00E1"),
@@ -2265,3 +2283,4 @@ list =
     ("zwj", "\x200D"),
     ("zwnj", "\x200C")
   ]
+  |]

--- a/library/HTMLEntities/Prelude.hs
+++ b/library/HTMLEntities/Prelude.hs
@@ -1,5 +1,8 @@
+{-# OPTIONS -Wno-missing-fields #-}
+
 module HTMLEntities.Prelude
   ( module Exports,
+    literally, lit, litFile
   )
 where
 
@@ -57,6 +60,8 @@ import GHC.Exts as Exports (IsList (..), groupWith, inline, lazy, sortWith)
 import GHC.Generics as Exports (Generic)
 import GHC.IO.Exception as Exports
 import GHC.OverloadedLabels as Exports
+import Language.Haskell.TH
+import Language.Haskell.TH.Quote
 import Numeric as Exports
 import System.Environment as Exports
 import System.Exit as Exports
@@ -68,3 +73,12 @@ import System.Mem.StableName as Exports
 import System.Timeout as Exports
 import Unsafe.Coerce as Exports
 import Prelude as Exports hiding (Read, all, and, any, concat, concatMap, elem, fail, foldl, foldl1, foldr, foldr1, id, mapM, mapM_, maximum, minimum, notElem, or, product, sequence, sequence_, sum, (.))
+
+literally :: String -> Q Exp
+literally = return . LitE . StringL
+
+lit :: QuasiQuoter
+lit = QuasiQuoter { quoteExp = literally }
+
+litFile :: QuasiQuoter
+litFile = quoteFile lit


### PR DESCRIPTION
Size redunction using ghc is 95%, from 2M to about 89K.  The improvement using GHCJS is about 99.5%, from 259M to 170K.  It uses a technique found here: https://stackoverflow.com/questions/12716215/load-pure-global-variable-from-file